### PR TITLE
Add validation for data methods

### DIFF
--- a/base/src/main/java/com/gluonhq/cloudlink/client/enterprise/CloudLinkClient.java
+++ b/base/src/main/java/com/gluonhq/cloudlink/client/enterprise/CloudLinkClient.java
@@ -53,6 +53,7 @@ public interface CloudLinkClient {
      * @throws javax.validation.ConstraintViolationException when the provided push notification object fails to
      * validate
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when <code>notification</code> is <code>null</code>
      */
     PushNotification sendPushNotification(@NotNull @Valid PushNotification notification);
 
@@ -65,6 +66,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the returned object
      * @return the object attached to the specified identifier or <code>null</code> if no such object exists
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Function<ObjectData, T> objectMapper);
 
@@ -77,6 +79,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the returned object
      * @return the object attached to the specified identifier or <code>null</code> if no such object exists
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Class<T> objectType);
 
@@ -90,6 +93,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the added object
      * @return the newly added object
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper);
 
@@ -102,6 +106,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the added object
      * @return the newly added object
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target);
 
@@ -115,7 +120,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the updated object
      * @return the updated object or <code>null</code> if no object exists with the specified identifier
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
-     * @throws NullPointerException when <code>target</code> or <code>objectMapper</code> is <code>null</code>
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper);
 
@@ -128,7 +133,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the updated object
      * @return the updated object or <code>null</code> if no object exists with the specified identifier
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
-     * @throws NullPointerException when <code>target</code> is <code>null</code>
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target);
 
@@ -137,6 +142,7 @@ public interface CloudLinkClient {
      *
      * @param objectId the identifier of the object to remove
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when <code>objectId</code> is <code>null</code>
      */
     void removeObject(@NotNull @Size(min = 1) String objectId);
 
@@ -149,6 +155,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the objects in the list
      * @return the list attached to the specified identifier
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Function<ObjectData, T> objectMapper);
 
@@ -161,6 +168,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the objects in the list
      * @return the list attached to the specified identifier
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Class<T> objectType);
 
@@ -174,6 +182,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the added object
      * @return the newly added object
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper);
 
@@ -186,6 +195,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the added object
      * @return the newly added object
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target);
 
@@ -200,6 +210,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the updated object
      * @return the updated object or <code>null</code> if no object exists in the list with the specified identifiers
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper);
 
@@ -213,6 +224,7 @@ public interface CloudLinkClient {
      * @param <T> the type of the updated object
      * @return the updated object or <code>null</code> if no object exists in the list with the specified identifiers
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target);
 
@@ -222,6 +234,7 @@ public interface CloudLinkClient {
      * @param listId the identifier of the list to remove the object from
      * @param objectId the identifier of the object to remove
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when any of the parameters is <code>null</code>
      */
     void removeFromList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId);
 

--- a/base/src/main/java/com/gluonhq/cloudlink/client/enterprise/CloudLinkClient.java
+++ b/base/src/main/java/com/gluonhq/cloudlink/client/enterprise/CloudLinkClient.java
@@ -36,6 +36,7 @@ import com.gluonhq.cloudlink.client.enterprise.domain.PushNotification;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.function.Function;
 
@@ -65,7 +66,7 @@ public interface CloudLinkClient {
      * @return the object attached to the specified identifier or <code>null</code> if no such object exists
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> T getObject(String objectId, Function<ObjectData, T> objectMapper);
+    <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Function<ObjectData, T> objectMapper);
 
     /**
      * Retrieve an object with the specified identifier. If no object with such an identifier exists,
@@ -77,7 +78,7 @@ public interface CloudLinkClient {
      * @return the object attached to the specified identifier or <code>null</code> if no such object exists
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> T getObject(String objectId, Class<T> objectType);
+    <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Class<T> objectType);
 
     /**
      * Adds the object with the specified identifier. If an object already exists with the specified identifier,
@@ -90,7 +91,7 @@ public interface CloudLinkClient {
      * @return the newly added object
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> T addObject(String objectId, T target, Function<ObjectData, T> objectMapper);
+    <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper);
 
     /**
      * Adds the object with the specified identifier. If an object already exists with the specified identifier,
@@ -102,7 +103,7 @@ public interface CloudLinkClient {
      * @return the newly added object
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> T addObject(String objectId, T target);
+    <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target);
 
     /**
      * Updates the object with the specified identifier. If no object exists with the specified identifier,
@@ -114,8 +115,9 @@ public interface CloudLinkClient {
      * @param <T> the type of the updated object
      * @return the updated object or <code>null</code> if no object exists with the specified identifier
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when <code>target</code> or <code>objectMapper</code> is <code>null</code>
      */
-    <T> T updateObject(String objectId, T target, Function<ObjectData, T> objectMapper);
+    <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper);
 
     /**
      * Updates the object with the specified identifier. If no object exists with the specified identifier,
@@ -126,8 +128,9 @@ public interface CloudLinkClient {
      * @param <T> the type of the updated object
      * @return the updated object or <code>null</code> if no object exists with the specified identifier
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
+     * @throws NullPointerException when <code>target</code> is <code>null</code>
      */
-    <T> T updateObject(String objectId, T target);
+    <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target);
 
     /**
      * Removes the object with the specified identifier.
@@ -135,7 +138,7 @@ public interface CloudLinkClient {
      * @param objectId the identifier of the object to remove
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    void removeObject(String objectId);
+    void removeObject(@NotNull @Size(min = 1) String objectId);
 
     /**
      * Retrieve a list with the specified identifier. The returned list contains the list of objects
@@ -147,7 +150,7 @@ public interface CloudLinkClient {
      * @return the list attached to the specified identifier
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> List<T> getList(String listId, Function<ObjectData, T> objectMapper);
+    <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Function<ObjectData, T> objectMapper);
 
     /**
      * Retrieve a list with the specified identifier. The returned list contains the list of objects
@@ -159,7 +162,7 @@ public interface CloudLinkClient {
      * @return the list attached to the specified identifier
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> List<T> getList(String listId, Class<T> objectType);
+    <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Class<T> objectType);
 
     /**
      * Adds an object to the list with the specified identifiers.
@@ -172,7 +175,7 @@ public interface CloudLinkClient {
      * @return the newly added object
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> T addToList(String listId, String objectId, T target, Function<ObjectData, T> objectMapper);
+    <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper);
 
     /**
      * Adds an object to the list with the specified identifiers.
@@ -184,7 +187,7 @@ public interface CloudLinkClient {
      * @return the newly added object
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> T addToList(String listId, String objectId, T target);
+    <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target);
 
     /**
      * Updates an existing object in the list with the specified identifiers. When the object with the specified
@@ -198,7 +201,7 @@ public interface CloudLinkClient {
      * @return the updated object or <code>null</code> if no object exists in the list with the specified identifiers
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> T updateInList(String listId, String objectId, T target, Function<ObjectData, T> objectMapper);
+    <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper);
 
     /**
      * Updates an existing object in the list with the specified identifiers. When the object with the specified
@@ -211,7 +214,7 @@ public interface CloudLinkClient {
      * @return the updated object or <code>null</code> if no object exists in the list with the specified identifiers
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    <T> T updateInList(String listId, String objectId, T target);
+    <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target);
 
     /**
      * Removes the object from the list with the specified identifiers.
@@ -220,6 +223,6 @@ public interface CloudLinkClient {
      * @param objectId the identifier of the object to remove
      * @throws CloudLinkClientException when an invalid HTTP response is returned from the request to Gluon CloudLink
      */
-    void removeFromList(String listId, String objectId);
+    void removeFromList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId);
 
 }

--- a/base/src/test/java/com/gluonhq/cloudlink/client/enterprise/CloudLinkClientValidationTest.java
+++ b/base/src/test/java/com/gluonhq/cloudlink/client/enterprise/CloudLinkClientValidationTest.java
@@ -1,0 +1,109 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2017, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.cloudlink.client.enterprise;
+
+import junit.framework.AssertionFailedError;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class CloudLinkClientValidationTest {
+
+    private Validator validator;
+
+    @Before
+    public void before() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @Test
+    public void validateGetObject() throws NoSuchMethodException {
+        String methodName = "getObject";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, Class.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", String.class});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", String.class});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", String.class});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateUpdateObject() throws NoSuchMethodException {
+        String methodName = "updateObject";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, Object.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", "sample"});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", "sample"});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", "sample"});
+        assertEquals(0, violations.size());
+    }
+
+    private <T> void assertMessageForProperty(Set<ConstraintViolation<T>> violations, String message, String propertyPath) {
+        ConstraintViolation violation = violations.stream()
+                .filter(v -> propertyPath.equals(v.getPropertyPath().toString()))
+                .findFirst().orElseThrow(() -> new AssertionFailedError("No constraint violation found for property path " + propertyPath));
+        assertEquals(message, violation.getMessage());
+    }
+}

--- a/base/src/test/java/com/gluonhq/cloudlink/client/enterprise/CloudLinkClientValidationTest.java
+++ b/base/src/test/java/com/gluonhq/cloudlink/client/enterprise/CloudLinkClientValidationTest.java
@@ -31,6 +31,7 @@
  */
 package com.gluonhq.cloudlink.client.enterprise;
 
+import com.gluonhq.cloudlink.client.enterprise.domain.PushNotification;
 import junit.framework.AssertionFailedError;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,6 +42,7 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.lang.reflect.Method;
 import java.util.Set;
+import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 
@@ -55,7 +57,56 @@ public class CloudLinkClientValidationTest {
     }
 
     @Test
-    public void validateGetObject() throws NoSuchMethodException {
+    public void validateSendPushNotification() throws NoSuchMethodException {
+        String methodName = "sendPushNotification";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, PushNotification.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+
+        PushNotification pushNotification = new PushNotification();
+        pushNotification.setExpirationType(PushNotification.ExpirationType.WEEKS);
+        pushNotification.setExpirationAmount(5);
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {pushNotification});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "value must be between 0 and 4 when using expiration type WEEKS", methodName + ".arg0.expirationAmount");
+
+        pushNotification.setExpirationAmount(3);
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {pushNotification});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateGetObjectByMapper() throws NoSuchMethodException {
+        String methodName = "getObject";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, Function.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+
+        Function mapper = (obj) -> obj;
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", mapper});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", mapper});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", mapper});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateGetObjectByClass() throws NoSuchMethodException {
         String methodName = "getObject";
 
         CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
@@ -74,6 +125,55 @@ public class CloudLinkClientValidationTest {
         assertEquals(0, violations.size());
 
         violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", String.class});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateAddObject() throws NoSuchMethodException {
+        String methodName = "addObject";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, Object.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", "sample"});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", "sample"});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", "sample"});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateAddObjectWithMapper() throws NoSuchMethodException {
+        String methodName = "addObject";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, Object.class, Function.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null, null});
+        assertEquals(3, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg2");
+
+        Function mapper = (obj) -> obj;
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", "sample", mapper});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", "sample", mapper});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", "sample", mapper});
         assertEquals(0, violations.size());
     }
 
@@ -97,6 +197,232 @@ public class CloudLinkClientValidationTest {
         assertEquals(0, violations.size());
 
         violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", "sample"});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateUpdateObjectWithMapper() throws NoSuchMethodException {
+        String methodName = "updateObject";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, Object.class, Function.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null, null});
+        assertEquals(3, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg2");
+
+        Function mapper = (obj) -> obj;
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", "sample", mapper});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", "sample", mapper});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", "sample", mapper});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateRemoveObject() throws NoSuchMethodException {
+        String methodName = "removeObject";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {""});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  "});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier"});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateGetListByMapper() throws NoSuchMethodException {
+        String methodName = "getList";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, Function.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+
+        Function mapper = (obj) -> obj;
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", mapper});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", mapper});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", mapper});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateGetListByClass() throws NoSuchMethodException {
+        String methodName = "getList";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, Class.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", String.class});
+        assertEquals(1, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", String.class});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"objectIdentifier", String.class});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateAddToList() throws NoSuchMethodException {
+        String methodName = "addToList";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, String.class, Object.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null, null});
+        assertEquals(3, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg2");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", "", "sample"});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", "  ", "sample"});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"listIdentifier", "objectIdentifier", "sample"});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateAddToListWithMapper() throws NoSuchMethodException {
+        String methodName = "addToList";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, String.class, Object.class, Function.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null, null, null});
+        assertEquals(4, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg2");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg3");
+
+        Function mapper = (obj) -> obj;
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", "", "sample", mapper});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", " ", "sample", mapper});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"listIdentifier", "objectIdentifier", "sample", mapper});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateUpdateInList() throws NoSuchMethodException {
+        String methodName = "updateInList";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, String.class, Object.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null, null});
+        assertEquals(3, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg2");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", "", "sample"});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", "  ", "sample"});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"listIdentifier", "objectIdentifier", "sample"});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateUpdateInListWithMapper() throws NoSuchMethodException {
+        String methodName = "updateInList";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, String.class, Object.class, Function.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null, null, null, null});
+        assertEquals(4, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg2");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg3");
+
+        Function mapper = (obj) -> obj;
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", "", "sample", mapper});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", "  ", "sample", mapper});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"listIdentifier", "objectIdentifier", "sample", mapper});
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    public void validateRemoveFromList() throws NoSuchMethodException {
+        String methodName = "removeFromList";
+
+        CloudLinkClient cloudLinkClient = new NotImplementedCloudLinkClient();
+        Method method = CloudLinkClient.class.getMethod(methodName, String.class, String.class);
+
+        Set<ConstraintViolation<CloudLinkClient>> violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {null,null});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg0");
+        assertMessageForProperty(violations, "may not be null", methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"", ""});
+        assertEquals(2, violations.size());
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg0");
+        assertMessageForProperty(violations, "size must be between 1 and " + Integer.MAX_VALUE, methodName + ".arg1");
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[] {"  ", "  "});
+        assertEquals(0, violations.size());
+
+        violations = validator.forExecutables().validateParameters(cloudLinkClient, method, new Object[]{"listIdentifier", "objectIdentifier"});
         assertEquals(0, violations.size());
     }
 

--- a/base/src/test/java/com/gluonhq/cloudlink/client/enterprise/NotImplementedCloudLinkClient.java
+++ b/base/src/test/java/com/gluonhq/cloudlink/client/enterprise/NotImplementedCloudLinkClient.java
@@ -40,6 +40,11 @@ import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.function.Function;
 
+/**
+ * Implementation of {@link CloudLinkClient} that throws a RuntimeException on
+ * each method call. This implementations is solely used for testing the bean
+ * validation of the CloudLinkClient methods.
+ */
 public class NotImplementedCloudLinkClient implements CloudLinkClient {
     @Override
     public PushNotification sendPushNotification(@NotNull @Valid PushNotification notification) {

--- a/base/src/test/java/com/gluonhq/cloudlink/client/enterprise/NotImplementedCloudLinkClient.java
+++ b/base/src/test/java/com/gluonhq/cloudlink/client/enterprise/NotImplementedCloudLinkClient.java
@@ -1,0 +1,118 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2017, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.cloudlink.client.enterprise;
+
+import com.gluonhq.cloudlink.client.enterprise.domain.ObjectData;
+import com.gluonhq.cloudlink.client.enterprise.domain.PushNotification;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.List;
+import java.util.function.Function;
+
+public class NotImplementedCloudLinkClient implements CloudLinkClient {
+    @Override
+    public PushNotification sendPushNotification(@NotNull @Valid PushNotification notification) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Function<ObjectData, T> objectMapper) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Class<T> objectType) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public void removeObject(@NotNull @Size(min = 1) String objectId) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Function<ObjectData, T> objectMapper) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Class<T> objectType) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public void removeFromList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+}

--- a/javaee/src/main/java/com/gluonhq/cloudlink/client/enterprise/javaee/JavaEECloudLinkClient.java
+++ b/javaee/src/main/java/com/gluonhq/cloudlink/client/enterprise/javaee/JavaEECloudLinkClient.java
@@ -140,6 +140,8 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public PushNotification sendPushNotification(@Valid @NotNull PushNotification notification) {
+        Objects.requireNonNull(notification, "notification may not be null");
+
         Form form = new Form();
         form.param("title", notification.getTitle())
                 .param("body", notification.getBody())
@@ -172,7 +174,9 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Function<ObjectData, T> objectMapper) {
-        Objects.requireNonNull(objectMapper);
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         Response response = webTarget.path("3").path("data").path("enterprise").path("object").path(objectId)
                 .request().get();
         if (response.getStatus() == 200) {
@@ -194,6 +198,9 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Class<T> objectType) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(objectType, "objectType may not be null");
+
         return getObject(objectId, data -> fromJson(data, objectType));
     }
 
@@ -202,7 +209,10 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
-        Objects.requireNonNull(objectMapper);
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         Response response = webTarget.path("3").path("data").path("enterprise").path("object").path(objectId).path("add")
                 .request().post(Entity.json(toJson(target)));
         if (response.getStatus() == 200) {
@@ -220,6 +230,9 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+
         return addObject(objectId, target, data -> fromJson(data, (Class<T>) target.getClass()));
     }
 
@@ -228,8 +241,10 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
-        Objects.requireNonNull(target);
-        Objects.requireNonNull(objectMapper);
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         Response response = webTarget.path("3").path("data").path("enterprise").path("object").path(objectId).path("update")
                 .request().post(Entity.json(toJson(target)));
         if (response.getStatus() == 200) {
@@ -251,6 +266,9 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+
         return updateObject(objectId, target, data -> fromJson(data, (Class<T>) target.getClass()));
     }
 
@@ -259,6 +277,8 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public void removeObject(@NotNull @Size(min = 1) String objectId) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+
         Response response = webTarget.path("3").path("data").path("enterprise").path("object").path(objectId).path("remove")
                 .request().post(Entity.form(new Form()));
         if (response.getStatus() != 200) {
@@ -271,7 +291,9 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Function<ObjectData, T> objectMapper) {
-        Objects.requireNonNull(objectMapper);
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         Response response = webTarget.path("3").path("data").path("enterprise").path("list").path(listId)
                 .request().get();
         if (response.getStatus() == 200) {
@@ -289,7 +311,9 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Class<T> objectType) {
-        Objects.requireNonNull(objectType);
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectType, "objectType may not be null");
+
         Jsonb jsonb = JsonbBuilder.create();
         return getList(listId, data -> jsonb.fromJson(data.getPayload(), objectType));
     }
@@ -299,7 +323,11 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
-        Objects.requireNonNull(objectMapper);
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         Jsonb jsonb = JsonbBuilder.create();
         Response response = webTarget.path("3").path("data").path("enterprise").path("list").path(listId).path("add").path(objectId)
                 .request().post(Entity.json(jsonb.toJson(target)));
@@ -318,6 +346,10 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+
         Jsonb jsonb = JsonbBuilder.create();
         return addToList(listId, objectId, target, data -> jsonb.fromJson(data.getPayload(), (Class<T>) target.getClass()));
     }
@@ -327,6 +359,11 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         Objects.requireNonNull(objectMapper);
         Jsonb jsonb = JsonbBuilder.create();
         Response response = webTarget.path("3").path("data").path("enterprise").path("list").path(listId).path("update").path(objectId)
@@ -350,6 +387,10 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+
         Jsonb jsonb = JsonbBuilder.create();
         return updateInList(listId, objectId, target, data -> jsonb.fromJson(data.getPayload(), (Class<T>) target.getClass()));
     }
@@ -359,6 +400,9 @@ public class JavaEECloudLinkClient implements CloudLinkClient {
      */
     @Override
     public void removeFromList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+
         Response response = webTarget.path("3").path("data").path("enterprise").path("list").path(listId).path("remove").path(objectId)
                 .request().post(Entity.form(new Form()));
         if (response.getStatus() != 200) {

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile 'io.github.openfeign:feign-okhttp:9.4.0'
     compile 'io.github.openfeign.form:feign-form:2.1.0'
 
+    compile 'org.springframework:spring-web:4.3.8.RELEASE'
     compile 'org.springframework.boot:spring-boot-autoconfigure:1.5.3.RELEASE'
 
     testCompile 'junit:junit:4.12'

--- a/spring/src/main/java/com/gluonhq/cloudlink/client/enterprise/spring/SpringCloudLinkClient.java
+++ b/spring/src/main/java/com/gluonhq/cloudlink/client/enterprise/spring/SpringCloudLinkClient.java
@@ -138,6 +138,8 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public PushNotification sendPushNotification(@NotNull @Valid PushNotification notification) {
+        Objects.requireNonNull(notification, "notification may not be null");
+
         return feignClient.sendPushNotification(
                 notification.getTitle(),
                 notification.getBody(),
@@ -156,6 +158,9 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Function<ObjectData, T> objectMapper) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         ObjectData objData = feignClient.getObject(objectId);
         if (objData.getUid() == null) {
             return null;
@@ -169,6 +174,9 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T getObject(@NotNull @Size(min = 1) String objectId, @NotNull Class<T> objectType) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(objectType, "objectType may not be null");
+
         ObjectData objData = feignClient.getObject(objectId);
         if (objData.getUid() == null) {
             return null;
@@ -182,6 +190,10 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         ObjectData objData = feignClient.addObject(objectId, toJson(target));
         return objectMapper.apply(objData);
     }
@@ -192,6 +204,9 @@ public class SpringCloudLinkClient implements CloudLinkClient {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T addObject(@NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+
         ObjectData objData = feignClient.addObject(objectId, toJson(target));
         return fromJson(objData, (Class<T>) target.getClass());
     }
@@ -201,6 +216,10 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         ObjectData objData = feignClient.updateObject(objectId, toJson(target));
         if (objData.getUid() == null) {
             return null;
@@ -215,6 +234,9 @@ public class SpringCloudLinkClient implements CloudLinkClient {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T updateObject(@NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+
         ObjectData objData = feignClient.updateObject(objectId, toJson(target));
         if (objData.getUid() == null) {
             return null;
@@ -228,6 +250,8 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public void removeObject(@NotNull @Size(min = 1) String objectId) {
+        Objects.requireNonNull(objectId, "objectId may not be null");
+
         feignClient.removeObject(objectId);
     }
 
@@ -236,6 +260,9 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Function<ObjectData, T> objectMapper) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         List<ObjectData> objDataList = feignClient.getList(listId);
         return objDataList.stream().map(objectMapper).collect(Collectors.toList());
     }
@@ -245,6 +272,9 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> List<T> getList(@NotNull @Size(min = 1) String listId, @NotNull Class<T> objectType) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectType, "objectType may not be null");
+
         List<ObjectData> objDataList = feignClient.getList(listId);
         return objDataList.stream().map(objData -> fromJson(objData, objectType)).collect(Collectors.toList());
     }
@@ -254,6 +284,11 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         ObjectData objData = feignClient.addToList(listId, objectId, gson.toJson(target));
         return objectMapper.apply(objData);
     }
@@ -264,6 +299,10 @@ public class SpringCloudLinkClient implements CloudLinkClient {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T addToList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+
         ObjectData objData = feignClient.addToList(listId, objectId, gson.toJson(target));
         return fromJson(objData, (Class<T>) target.getClass());
     }
@@ -273,6 +312,11 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target, @NotNull Function<ObjectData, T> objectMapper) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+        Objects.requireNonNull(objectMapper, "objectMapper may not be null");
+
         ObjectData objData = feignClient.updateInList(listId, objectId, gson.toJson(target));
         if (objData.getUid() == null) {
             return null;
@@ -287,6 +331,10 @@ public class SpringCloudLinkClient implements CloudLinkClient {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T updateInList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId, @NotNull T target) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+        Objects.requireNonNull(target, "target may not be null");
+
         ObjectData objData = feignClient.updateInList(listId, objectId, gson.toJson(target));
         if (objData.getUid() == null) {
             return null;
@@ -300,6 +348,9 @@ public class SpringCloudLinkClient implements CloudLinkClient {
      */
     @Override
     public void removeFromList(@NotNull @Size(min = 1) String listId, @NotNull @Size(min = 1) String objectId) {
+        Objects.requireNonNull(listId, "listId may not be null");
+        Objects.requireNonNull(objectId, "objectId may not be null");
+
         feignClient.removeFromList(listId, objectId);
     }
 


### PR DESCRIPTION
This pull request includes the following changes:

- extra bean validation added on all methods for the data service
- add in simple null checks for all parameters where needed
- spring: activated bean validation on SpringCloudLinkClient by defining Validated annotation
- spring: add spring web exception mapper on ConstraintViolationException for improved detailed response in case of validation error
- javaee: validation is done in an AroundInvoke CDI interceptor