### PR TITLE
Introduce customIdentifier field on push notification

### DIFF
--- a/javaee/src/main/java/com/gluonhq/cloudlink/enterprise/sdk/javaee/CloudLinkClient.java
+++ b/javaee/src/main/java/com/gluonhq/cloudlink/enterprise/sdk/javaee/CloudLinkClient.java
@@ -146,7 +146,8 @@ public class CloudLinkClient {
         Objects.requireNonNull(notification, "notification may not be null");
 
         Form form = new Form();
-        form.param("title", notification.getTitle())
+        form.param("customIdentifier", notification.getCustomIdentifier())
+                .param("title", notification.getTitle())
                 .param("body", notification.getBody())
                 .param("deliveryDate", "0")
                 .param("priority", notification.getPriority().name())

--- a/javaee/src/main/java/com/gluonhq/cloudlink/enterprise/sdk/javaee/domain/PushNotification.java
+++ b/javaee/src/main/java/com/gluonhq/cloudlink/enterprise/sdk/javaee/domain/PushNotification.java
@@ -45,6 +45,7 @@ public class PushNotification {
 
     private String identifier;
     private long creationDate;
+    private String customIdentifier = "";
     private String title = "";
     private String body = "";
     private long deliveryDate = 0;
@@ -112,6 +113,25 @@ public class PushNotification {
      */
     public void setCreationDate(long creationDate) {
         this.creationDate = creationDate;
+    }
+
+    /**
+     * Returns the custom identifier for the push notification.
+     *
+     * @return the custom identifier for the push notification
+     */
+    @NotNull
+    public String getCustomIdentifier() {
+        return customIdentifier;
+    }
+
+    /**
+     * Sets the custom identifier for the push notification.
+     *
+     * @param customIdentifier the custom identifier of the push notification
+     */
+    public void setCustomIdentifier(String customIdentifier) {
+        this.customIdentifier = customIdentifier;
     }
 
     /**
@@ -317,6 +337,7 @@ public class PushNotification {
     public String toString() {
         return "PushNotification{" +
                 "identifier='" + identifier + '\'' +
+                ", customIdentifier='" + customIdentifier + '\'' +
                 ", title='" + title + '\'' +
                 ", body='" + body + '\'' +
                 ", deliveryDate=" + deliveryDate +

--- a/javaee/src/test/java/com/gluonhq/cloudlink/enterprise/sdk/javaee/PushTest.java
+++ b/javaee/src/test/java/com/gluonhq/cloudlink/enterprise/sdk/javaee/PushTest.java
@@ -53,6 +53,7 @@ public class PushTest {
     @Test
     public void sendPushNotification() {
         String identifier = UUID.randomUUID().toString();
+        String customIdentifier = UUID.randomUUID().toString();
 
         HttpServer httpServer = null;
         try {
@@ -61,7 +62,10 @@ public class PushTest {
 
                 if (request.method() == HttpMethod.POST) {
                     request.endHandler(event -> {
-                        if (!"Title".equals(request.getFormAttribute("title"))) {
+                        if (!"CustomId".equals(request.getFormAttribute("customIdentifier"))) {
+                            request.response().setStatusCode(500)
+                                    .end("Expected <CustomId> but was: <" + request.getFormAttribute("customIdentifier") + ">");
+                        } else if (!"Title".equals(request.getFormAttribute("title"))) {
                             request.response().setStatusCode(500)
                                     .end("Expected: <Title> but was: <" + request.getFormAttribute("title") + ">");
                         } else if (!"Body".equals(request.getFormAttribute("body"))) {
@@ -88,7 +92,7 @@ public class PushTest {
                         } else {
                             request.response()
                                     .setStatusCode(200)
-                                    .end("{\"identifier\":\"" + identifier + "\"}");
+                                    .end("{\"identifier\":\"" + identifier + "\",\"customIdentifier\":\"" + customIdentifier + "\"}");
                         }
                     });
                 } else {
@@ -101,6 +105,7 @@ public class PushTest {
             CloudLinkClient client = new CloudLinkClient(config);
 
             PushNotification pushNotification = new PushNotification();
+            pushNotification.setCustomIdentifier("CustomId");
             pushNotification.setTitle("Title");
             pushNotification.setBody("Body");
             pushNotification.setPriority(PushNotification.Priority.HIGH);
@@ -112,6 +117,7 @@ public class PushTest {
 
             Assert.assertNotNull(notification);
             Assert.assertEquals(identifier, notification.getIdentifier());
+            Assert.assertEquals(customIdentifier, notification.getCustomIdentifier());
         } catch (CloudLinkClientException e) {
             fail(e.getBody());
         } finally {

--- a/spring/src/main/java/com/gluonhq/cloudlink/enterprise/sdk/spring/CloudLinkClient.java
+++ b/spring/src/main/java/com/gluonhq/cloudlink/enterprise/sdk/spring/CloudLinkClient.java
@@ -146,6 +146,7 @@ public class CloudLinkClient {
         Objects.requireNonNull(notification, "notification may not be null");
 
         return feignClient.sendPushNotification(
+                notification.getCustomIdentifier(),
                 notification.getTitle(),
                 notification.getBody(),
                 notification.getDeliveryDate(),

--- a/spring/src/main/java/com/gluonhq/cloudlink/enterprise/sdk/spring/domain/PushNotification.java
+++ b/spring/src/main/java/com/gluonhq/cloudlink/enterprise/sdk/spring/domain/PushNotification.java
@@ -45,6 +45,7 @@ public class PushNotification {
 
     private String identifier;
     private long creationDate;
+    private String customIdentifier = "";
     private String title = "";
     private String body = "";
     private long deliveryDate = 0;
@@ -112,6 +113,25 @@ public class PushNotification {
      */
     public void setCreationDate(long creationDate) {
         this.creationDate = creationDate;
+    }
+
+    /**
+     * Returns the custom identifier for the push notification.
+     *
+     * @return the custom identifier for the push notification
+     */
+    @NotNull
+    public String getCustomIdentifier() {
+        return customIdentifier;
+    }
+
+    /**
+     * Sets the custom identifier for the push notification.
+     *
+     * @param customIdentifier the custom identifier of the push notification
+     */
+    public void setCustomIdentifier(String customIdentifier) {
+        this.customIdentifier = customIdentifier;
     }
 
     /**
@@ -317,6 +337,7 @@ public class PushNotification {
     public String toString() {
         return "PushNotification{" +
                 "identifier='" + identifier + '\'' +
+                ", customIdentifier='" + customIdentifier + '\'' +
                 ", title='" + title + '\'' +
                 ", body='" + body + '\'' +
                 ", deliveryDate=" + deliveryDate +

--- a/spring/src/main/java/com/gluonhq/impl/cloudlink/enterprise/sdk/spring/FeignClient.java
+++ b/spring/src/main/java/com/gluonhq/impl/cloudlink/enterprise/sdk/spring/FeignClient.java
@@ -54,7 +54,8 @@ public interface FeignClient {
     @Path("push/enterprise/notification")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_JSON + "; " + CHARSET)
-    PushNotification sendPushNotification(@FormParam("title") String title,
+    PushNotification sendPushNotification(@FormParam("customIdentifier") String customIdentifier,
+            @FormParam("title") String title,
             @FormParam("body") String body,
             @FormParam("deliveryDate") long deliveryDate,
             @FormParam("priority") PushNotification.Priority priority,

--- a/spring/src/test/java/com/gluonhq/cloudlink/enterprise/sdk/spring/PushTest.java
+++ b/spring/src/test/java/com/gluonhq/cloudlink/enterprise/sdk/spring/PushTest.java
@@ -51,6 +51,7 @@ public class PushTest {
     @Test
     public void sendPushNotification() {
         String identifier = UUID.randomUUID().toString();
+        String customIdentifier = UUID.randomUUID().toString();
 
         HttpServer httpServer = null;
         try {
@@ -59,7 +60,10 @@ public class PushTest {
 
                 if (request.method() == HttpMethod.POST) {
                     request.endHandler(event -> {
-                        if (!"Title".equals(request.getFormAttribute("title"))) {
+                        if (!"CustomId".equals(request.getFormAttribute("customIdentifier"))) {
+                            request.response().setStatusCode(500)
+                                    .end("Expected <CustomId> but was: <" + request.getFormAttribute("customIdentifier") + ">");
+                        } else if (!"Title".equals(request.getFormAttribute("title"))) {
                             request.response().setStatusCode(500)
                                     .end("Expected: <Title> but was: <" + request.getFormAttribute("title") + ">");
                         } else if (!"Body".equals(request.getFormAttribute("body"))) {
@@ -86,7 +90,7 @@ public class PushTest {
                         } else {
                             request.response()
                                     .setStatusCode(200)
-                                    .end("{\"identifier\":\"" + identifier + "\"}");
+                                    .end("{\"identifier\":\"" + identifier + "\",\"customIdentifier\":\"" + customIdentifier + "\"}");
                         }
                     });
                 } else {
@@ -99,6 +103,7 @@ public class PushTest {
             CloudLinkClient client = new CloudLinkClient(config);
 
             PushNotification pushNotification = new PushNotification();
+            pushNotification.setCustomIdentifier("CustomId");
             pushNotification.setTitle("Title");
             pushNotification.setBody("Body");
             pushNotification.setPriority(PushNotification.Priority.HIGH);
@@ -110,6 +115,7 @@ public class PushTest {
 
             Assert.assertNotNull(notification);
             Assert.assertEquals(identifier, notification.getIdentifier());
+            Assert.assertEquals(customIdentifier, notification.getCustomIdentifier());
         } finally {
             if (httpServer != null) {
                 httpServer.close();


### PR DESCRIPTION
A custom identifier can be passed along with a push notification. The custom identifier is not visible to the user, but can be used by the developer to distinguish between different types of push notifications and do different actions based on the value of the custom identifier.